### PR TITLE
Final bulk of styling

### DIFF
--- a/src/components/auth/SignIn.js
+++ b/src/components/auth/SignIn.js
@@ -18,7 +18,15 @@ const box = {
   }
   
   const bgc = {
-    backgroundColor: 'lightgrey'
+    backgroundColor: 'lightgrey',
+    marginTop: "20px",
+    padding: '25px'
+  }
+
+  const title = {
+    fontSize: '40px',
+    textAlign: 'left',
+    margin: '20px'
   }
 
 const SignIn = (props) => {
@@ -66,7 +74,7 @@ const SignIn = (props) => {
     return (
         <div className='row'>
             <div className='col-sm-10 col-md-8 mx-auto mt-5' style={bgc}>
-                <h5>Sign In</h5>
+                <h1 style={title}>Sign In</h1>
                 <Form onSubmit={onSignIn}>
                 <div className='container' style={box}>
                     <Form.Group controlId='email'>

--- a/src/components/auth/SignUp.js
+++ b/src/components/auth/SignUp.js
@@ -17,10 +17,20 @@ const box = {
 const button = {
     margin: '10px',
 }
-
 const bgc = {
-    backgroundColor: 'lightgrey'
+    backgroundColor: 'lightgrey',
+    marginTop: "20px",
+    padding: '25px'
 }
+const title = {
+    fontSize: '40px',
+    textAlign: 'left',
+    margin: '20px'
+  }
+  
+  const subtitle = {
+      fontSize: '20px',
+  }
 
 const SignUp = (props) => {
     // constructor(props) {
@@ -71,11 +81,11 @@ const SignUp = (props) => {
     return (
         <div className='row'>
             <div className='col-sm-10 col-md-8 mx-auto mt-5' style={bgc}>
-                <h5>Sign Up</h5>
+                <h1 style={title}>Sign Up</h1>
                 <Form onSubmit={onSignUp}>
                     <div className='container' style={box}>
                         <Form.Group controlId='email'>
-                            <Form.Label>Email address</Form.Label>
+                            <Form.Label style={subtitle}>Email address</Form.Label>
                             <Form.Control
                                 style={{ width: '18rem' }}
                                 required
@@ -90,7 +100,7 @@ const SignUp = (props) => {
 
                     <div className='container' style={box}>
                         <Form.Group controlId='password'>
-                            <Form.Label>Password</Form.Label>
+                            <Form.Label style={subtitle}>Password</Form.Label>
                             <Form.Control
                                 style={{ width: '18rem' }}
                                 required
@@ -105,7 +115,7 @@ const SignUp = (props) => {
 
                     <div className='container' style={box}>
                         <Form.Group controlId='passwordConfirmation'>
-                            <Form.Label>Password Confirmation</Form.Label>
+                            <Form.Label style={subtitle}>Password Confirmation</Form.Label>
                             <Form.Control
                                 style={{ width: '18rem' }}
                                 required

--- a/src/components/homeComponents/Cards.js
+++ b/src/components/homeComponents/Cards.js
@@ -5,25 +5,20 @@ import Photo1 from "./../homeComponents/images/photo1.jpeg"
 import Photo2 from "./../homeComponents/images/Modern1.jpeg"
 import Photo3 from "./../homeComponents/images/pop.jpeg"
 
-
 const cardstyle = {
     margin: '25px',
     height: '400px'
 }
-
 const image = {
     height: '80%',
     objectFit: 'cover'
 }
-
 const text = {
     textAlign: 'center',
     textDecoration: 'none',
     color: 'black',
     fontSize: '25px'
 }
-
-
 
 const Cards = () => {
 

--- a/src/components/homeComponents/Cards_About.js
+++ b/src/components/homeComponents/Cards_About.js
@@ -1,35 +1,25 @@
 import React from 'react'
 import { Card, CardGroup } from 'react-bootstrap'
-import { Link } from 'react-router-dom'
-import Photo1 from "./../homeComponents/images/photo1.jpeg"
-import Photo2 from "./../homeComponents/images/Modern1.jpeg"
-import Photo3 from "./../homeComponents/images/pop.jpeg"
-
 
 const cardstyle = {
     margin: '25px',
     height: '400px',
     border: "none"
 }
-
 const image = {
     // height: '80%',
     objectFit: 'cover',
     borderRadius: '50%'
 }
-
 const text = {
     textAlign: 'center',
     textDecoration: 'none',
     color: 'black',
     fontSize: '25px'
 }
-
 const link = {
     color: '#74AFA3'
 }
-
-
 
 const Cards = () => {
 
@@ -50,7 +40,7 @@ const Cards = () => {
                 <Card style={cardstyle}>
                     <Card.Img variant="top" src='https://media-exp1.licdn.com/dms/image/C4D03AQEM60PeYsCnsg/profile-displayphoto-shrink_400_400/0/1602781791357?e=1645056000&v=beta&t=W2DP_TTwjo5JI6OkQamqUxPY-6QNaityvsD3qpRIlXo' style={image} />
                     <Card.Body>
-                    <Card.Text style={text}>
+                        <Card.Text style={text}>
                             <h4>Isaac Newman</h4>
                             <h6><a href="https://github.com/isaac8069" style={link} target="_blank">Github</a></h6>
                             <h6><a href="https://www.linkedin.com/in/lonewman/" style={link} target="_blank">LinkedIn</a></h6>
@@ -61,18 +51,18 @@ const Cards = () => {
                 <Card style={cardstyle}>
                     <Card.Img variant="top" src='https://media-exp1.licdn.com/dms/image/C4D03AQEWHHbxAv5cug/profile-displayphoto-shrink_400_400/0/1597330190093?e=1645056000&v=beta&t=nH70b6DiDZHY1iLqXRAlCypkTJKWFPMiqM_X74qi8og' style={image} />
                     <Card.Body>
-                    <Card.Text style={text}>
+                        <Card.Text style={text}>
                             <h4>Isaac Waggoner</h4>
                             <h6><a href="https://github.com/iwaggoner" style={link} target="_blank">Github</a></h6>
                             <h6><a href="https://www.linkedin.com/in/iwaggoner/" style={link} target="_blank">LinkedIn</a></h6>
-                        </Card.Text>
+                            </Card.Text>
                     </Card.Body>
                 </Card>
                 <br />
                 <Card style={cardstyle}>
                     <Card.Img variant="top" src='https://media-exp1.licdn.com/dms/image/C5603AQHhWAYMpDoD9Q/profile-displayphoto-shrink_400_400/0/1581896475156?e=1645056000&v=beta&t=w90-0-fqvToz6iOUDf21Zmqo2IRlMml696PaFuagKrk' style={image} />
                     <Card.Body>
-                    <Card.Text style={text}>
+                        <Card.Text style={text}>
                             <h4>Michael Kohlberg</h4>
                             <h6><a href="https://github.com/mgkdn9" style={link} target="_blank">Github</a></h6>
                             <h6><a href="https://www.linkedin.com/in/michaelkohlberg/" style={link} target="_blank">LinkedIn</a></h6>

--- a/src/components/homeComponents/Carousel.js
+++ b/src/components/homeComponents/Carousel.js
@@ -2,10 +2,6 @@ import React, { useState } from "react"
 import { Carousel } from "react-bootstrap"
 import Image1 from "./../homeComponents/images/car1.jpeg"
 import Image3 from "./../homeComponents/images/car2.jpeg"
-// import Image1 from "./../homeComponents/images/car1test.jpg"
-// import Image2 from "./../homeComponents/images/new2.jpeg"
-// import Image3 from "./../homeComponents/images/car2test2.jpg"
-
 
 const carstyle = {
   maxHeight: '400px',
@@ -14,14 +10,8 @@ const carstyle = {
   marginTop: '50px'
 }
 
-const caption = {
-  top: "220px",
-  color: "white",
-}
-
 const CarouselImage = () => {
   const [index, setIndex] = useState(0);
-
   const handleSelect = (selectedIndex, e) => {
     setIndex(selectedIndex)
   }
@@ -35,10 +25,6 @@ const CarouselImage = () => {
           style={carstyle}
           alt="First slide"
         />
-        {/* <Carousel.Caption style={caption}>
-          <h1>Refresh your art...</h1>
-          <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
-        </Carousel.Caption> */}
       </Carousel.Item>
       <Carousel.Item>
         <img
@@ -47,26 +33,7 @@ const CarouselImage = () => {
           style={carstyle}
           alt="Second slide"
         />
-        {/* <Carousel.Caption style={caption}>
-          <h1>from the comfort of home.</h1>
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-        </Carousel.Caption> */}
       </Carousel.Item>
-      {/* <Carousel.Item>
-        <img
-          className="d-block w-100"
-          src={Image2}
-          style={carstyle}
-          alt="Third slide"
-        />
-
-        <Carousel.Caption style={caption}>
-          <h1>Third slide label</h1>
-          <p>
-            Praesent commodo cursus magna, vel scelerisque nisl consectetur.
-          </p>
-        </Carousel.Caption>
-      </Carousel.Item> */}
     </Carousel>
   )
 }

--- a/src/components/homeComponents/Community.js
+++ b/src/components/homeComponents/Community.js
@@ -3,21 +3,19 @@ import { Card, CardGroup } from "react-bootstrap"
 import CommunityImage from "./../homeComponents/images/community1.jpeg"
 import CommunityImage2 from "./../homeComponents/images/community2.jpg"
 
-
 const communitystyle = {
     height: '400px',
     objectFit: 'cover'
 }
-
 const communitystyle2 = {
     height: '400px',
     objectFit: 'cover'
 }
-
 const space = {
     textAlign: "center",
     margin: '45px'
 }
+
 const Community = () => {
 
     return (
@@ -36,7 +34,7 @@ const Community = () => {
                             "I love switching out my artwork each season, and I don't even have to leave my house."
                         </Card.Text>
                         <Card.Text>
-                            "I started out with the lowest tier of artwork delivery (1 per season) and now I am receiving 8 per season and couldn't be happier that my house is turning into an art museum!"
+                            "I started out with the lowest tier of artwork delivery (1 per season) and now I am receiving 6 per season and couldn't be happier that my house is turning into an art museum!"
                         </Card.Text>
                         <Card.Text>
                             "I no longer need an interior designer to handle my artwork for me."

--- a/src/components/homeComponents/Plans.js
+++ b/src/components/homeComponents/Plans.js
@@ -11,56 +11,51 @@ const cardstyle = {
     border: "none"
 
 }
-
 const text = {
     fontSize: '40px',
     width: "400px",
     marginTop: '40px'
 }
-
 const text2 = {
   fontSize: '15px',
   width: "400px",
   marginTop: '20px',
   marginBottom: '20px'
 }
-
 const image = {
   minWidth: "400px"
 }
 
 const PlansSection = () => {
-
   const navigate = useNavigate()
-const handleClick = (e) =>{
-  return(
-    navigate('/subscription')
-  )
-}
-return (
-<div>
+  const handleClick = (e) =>{
+    return(
+      navigate('/subscription')
+    )
+  }
+  return (
+  <div>
     <div className="row">
       <div className="col">
-      <Card style={cardstyle}>
-        <Card.Img variant="top" src={PlansImage} style={image} />
-      </Card>
+        <Card style={cardstyle}>
+          <Card.Img variant="top" src={PlansImage} style={image} />
+        </Card>
       </div>
       <br />
       <div className="col">
-      <Card style={cardstyle}>
-      <Card.Body>
-        <Card.Title style={text}>Explore Our Subscriptions</Card.Title>
-        <Card.Text style={text2}>
-          We have a plan for every budget, tiered by the number of art pieces delivered each season.
-        </Card.Text>
-        <Button variant="dark" onClick={handleClick}>Learn More</Button>
-       </Card.Body>
-      </Card>
+        <Card style={cardstyle}>
+        <Card.Body>
+          <Card.Title style={text}>Explore Our Subscriptions</Card.Title>
+          <Card.Text style={text2}>
+            We have a plan for every budget, tiered by the number of art pieces delivered each season.
+          </Card.Text>
+          <Button variant="dark" onClick={handleClick}>Learn More</Button>
+        </Card.Body>
+        </Card>
       </div>
     </div>
-
-</div>
-)
+  </div>
+  )
 }
 
 export default PlansSection

--- a/src/components/pages/About_Folder/About.js
+++ b/src/components/pages/About_Folder/About.js
@@ -34,7 +34,7 @@ const About = (props) => {
 			</h1>
             <p style={subtitle}>This project was in partial fulfillment for the General Assembly Software Engineering Immersive program in December 2021. Our project's <a href="https://github.com/isaac8069/Re-Art-Client" style={link} target="_blank">Github repository</a> has more information about our collaborative process and project documentation.</p>
             <p style={subtitle}>Tech Stack: MongoDB, Express, React, Node</p>
-			<div>
+			<div style={{maxWidth: "1100px", margin: "0 auto"}}>
 				<Cards />
 			</div>
 			

--- a/src/components/pages/About_Folder/About.js
+++ b/src/components/pages/About_Folder/About.js
@@ -4,13 +4,11 @@ const text = {
 	margin: '50px',
 	fontSize: '40px'
 }
-
 const title = {
 	fontSize: '40px',
 	textAlign: 'center',
 	margin: '50px'
 }
-
 const subtitle = {
 	fontSize: '20px',
 	textAlign: 'center',
@@ -18,7 +16,6 @@ const subtitle = {
 	margin: "0 auto",
 	paddingBottom: "20px"
 }
-
 const link = {
     color: '#74AFA3'
 }
@@ -26,7 +23,6 @@ const link = {
 const About = (props) => {
 	// const { msgAlert, user } = props
 	// console.log('props in home', props)
-
 	return (
 		<>
             <h1 style={title}>
@@ -37,7 +33,6 @@ const About = (props) => {
 			<div style={{maxWidth: "1100px", margin: "0 auto"}}>
 				<Cards />
 			</div>
-			
 		</>
 	)
 }

--- a/src/components/pages/Art_Folder/Art.js
+++ b/src/components/pages/Art_Folder/Art.js
@@ -1,6 +1,20 @@
 import React, { useState, useEffect } from 'react'
 // Import Pieces to show each art piece
-import Pieces from './Pieces'
+import Pieces from './Pieces_All'
+
+const title = {
+    fontSize: '40px',
+    textAlign: 'center',
+    margin: '38px 0px 20px 0px'
+  }
+  
+  const subtitle = {
+    fontSize: '20px',
+    textAlign: 'center',
+    width: "720px",
+    margin: "0 auto",
+    paddingBottom: "20px"
+  }
 
 const Art = (props) => {
 
@@ -24,13 +38,19 @@ const Art = (props) => {
             artist = {a.artist}
             imgUrl = {a.imgUrl}
             description = {a.description}
-            price = {a.price}
+            // price = {a.price}
         />
     })
 
     return (
         <div>
-            {pieces}
+            <h1 style={title}>
+				The Collection
+			</h1>
+            <p style={subtitle}>Browse a portion of our collection below- the possibilities are endless! Once you create a profile, you can list keywords to begin filtering the artwork by style.</p>
+            <div className = "row">            
+                {pieces}
+            </div>
         </div>
     )
 }

--- a/src/components/pages/Art_Folder/Art.js
+++ b/src/components/pages/Art_Folder/Art.js
@@ -7,7 +7,6 @@ const title = {
     textAlign: 'center',
     margin: '38px 0px 20px 0px'
   }
-  
   const subtitle = {
     fontSize: '20px',
     textAlign: 'center',

--- a/src/components/pages/Art_Folder/Filtered_Art.js
+++ b/src/components/pages/Art_Folder/Filtered_Art.js
@@ -92,7 +92,7 @@ const Filtered_Art = (props) => {
               </div>
           </div>
           <ul>
-            <p style={subtitle}>Below is a sampling of the artwork we will send you, based on your profile preferences of:</p>
+            <p style={subtitle}>You have selected our <strong>Basic Access</strong> package. Below is a sampling of the artwork we will send you, based on your profile preferences of:</p>
                   {props.profile.tags.map((tag)=>{
                         return <li style={list}>{tag.name}</li>
                     }) } 

--- a/src/components/pages/Art_Folder/Filtered_Art.js
+++ b/src/components/pages/Art_Folder/Filtered_Art.js
@@ -31,7 +31,6 @@ const button = {
   }
 
   const list = {
-    marginBottom: "40px",
     textAlign: 'center',
     listStyleType: 'none'
   }

--- a/src/components/pages/Art_Folder/Filtered_Art.js
+++ b/src/components/pages/Art_Folder/Filtered_Art.js
@@ -4,11 +4,36 @@ import Pieces from './Pieces'
 // navigate for redirecting to checkout
 import { useNavigate } from 'react-router-dom'
 // button styling
-import { Button, Card, Row, Col, CardGroup } from 'react-bootstrap'
+import { Button } from 'react-bootstrap'
 
 
 const button = {
-    margin: '10px',
+    marginTop: '40px',
+  }
+
+  const buttonContainer = {
+    float: "right",
+    marginRight: '30px'
+  }
+
+  const title = {
+    fontSize: '40px',
+    textAlign: 'center',
+    margin: '38px 0px 20px 180px'
+  }
+  
+  const subtitle = {
+    fontSize: '20px',
+    textAlign: 'center',
+    width: "720px",
+    margin: "0 auto",
+    paddingBottom: "20px"
+  }
+
+  const list = {
+    marginBottom: "40px",
+    textAlign: 'center',
+    listStyleType: 'none'
   }
 
 
@@ -59,23 +84,24 @@ const Filtered_Art = (props) => {
 
     return (
         <div>
-            <div className="row">
-                <div className = "col">
-                    <h3>Our art, your preferences. </h3>
-                </div>
-                <div className = "col">
-                    <Button onClick={redirectToCheckout} variant="light" style={button} className = "btn btn-outline-success">Proceed to Checkout <text>&#8594;</text></Button>
-                </div>
+          <div style={buttonContainer}>
+              <Button onClick={redirectToCheckout} variant="light" style={button} className = "btn btn-outline-success">Proceed to Checkout <text>&#8594;</text></Button>
+          </div>
+          <div className="row">
+              <div className = "col">
+                <h3 style={title}>Our art, based on <em>your</em> preferences. </h3>
               </div>
-                        {/* used to work now it doesn't consistently{
-                    props.profile.tags.map((tag)=>{
-                        return tag.name
-                    }) } */}
-                    <p>Below is a sampling of the artwork we will send you, based on your profile preferences. You can update preferences anytime in your profile.</p>
-        
-              <div className = "row">            
-                {pieces}
-              </div>
+          </div>
+          <ul>
+            <p style={subtitle}>Below is a sampling of the artwork we will send you, based on your profile preferences of:</p>
+                  {props.profile.tags.map((tag)=>{
+                        return <li style={list}>{tag.name}</li>
+                    }) } 
+          </ul>
+
+          <div className = "row">            
+            {pieces}
+          </div>
         </div>
     )
 }

--- a/src/components/pages/Art_Folder/Filtered_Art.js
+++ b/src/components/pages/Art_Folder/Filtered_Art.js
@@ -10,18 +10,15 @@ import { Button } from 'react-bootstrap'
 const button = {
     marginTop: '40px',
   }
-
   const buttonContainer = {
     float: "right",
     marginRight: '30px'
   }
-
   const title = {
     fontSize: '40px',
     textAlign: 'center',
     margin: '38px 0px 20px 180px'
   }
-  
   const subtitle = {
     fontSize: '20px',
     textAlign: 'center',
@@ -29,71 +26,66 @@ const button = {
     margin: "0 auto",
     paddingBottom: "20px"
   }
-
   const list = {
     textAlign: 'center',
     listStyleType: 'none'
   }
 
-
 const Filtered_Art = (props) => {
-
   console.log('Profile: ',props.profile)
   const navigate = useNavigate()
+  // State that holds all objects from Server
+  const [art, setArt] = useState([])
+  // useEffect that access the Server API
+  useEffect(() => {
+      fetch(`http://localhost:8000/pieces/profile/${props.profile._id}`)
+      .then(res => res.json())
+      .then(foundPieces=>{
+          // Sets API data to state allArt
+          setArt(foundPieces.pieces)
+      })
+  }, [])
 
-    // State that holds all objects from Server
-    const [art, setArt] = useState([])
-    // useEffect that access the Server API
-    useEffect(() => {
-        fetch(`http://localhost:8000/pieces/profile/${props.profile._id}`)
-        .then(res => res.json())
-        .then(foundPieces=>{
-            // Sets API data to state allArt
-            setArt(foundPieces.pieces)
-        })
-    }, [])
-
-    // Maps art state and passes info from object to Pieces component
-    let pieces = <h5>No Art Found! Make sure your art preferences are in your profile.</h5>
-    // console.log('art: ',art)
-    if(art){
-        pieces = art.map(a => {
-            return <Pieces
-                key={a._id}
-                title = {a.title}
-                artist = {a.artist}
-                imgUrl = {a.imgUrl}
-                description = {a.description}
-                // price = {a.price}
-            />
-        })
+  // Maps art state and passes info from object to Pieces component
+  let pieces = <h5>No Art Found! Make sure your art preferences are in your profile.</h5>
+  // console.log('art: ',art)
+  if(art){
+      pieces = art.map(a => {
+          return <Pieces
+              key={a._id}
+              title = {a.title}
+              artist = {a.artist}
+              imgUrl = {a.imgUrl}
+              description = {a.description}
+              // price = {a.price}
+          />
+      })
+  }
+  const redirectToCheckout = () => {
+      return navigate('/subscription/checkout')
     }
 
-    const redirectToCheckout = () => {
-        return navigate('/subscription/checkout')
-      }
-
-    return (
-        <div>
-          <div style={buttonContainer}>
-              <Button onClick={redirectToCheckout} variant="light" style={button} className = "btn btn-outline-success">Proceed to Checkout <text>&#8594;</text></Button>
-          </div>
-          <div className="row">
-              <div className = "col">
-                <h3 style={title}>Our art, based on <em>your</em> preferences. </h3>
-              </div>
-          </div>
-          <ul>
-            <p style={subtitle}>You have selected our <strong>Basic Access</strong> package. Below is a sampling of the artwork we will send you, based on your profile preferences of:</p>
-                  {props.profile.tags.map((tag)=>{
-                        return <li style={list}>{tag.name}</li>
-                    }) } 
-          </ul>
-          <div className = "row">            
-            {pieces}
-          </div>
+  return (
+      <div>
+        <div style={buttonContainer}>
+            <Button onClick={redirectToCheckout} variant="light" style={button} className = "btn btn-outline-success">Proceed to Checkout <text>&#8594;</text></Button>
         </div>
-    )
+        <div className="row">
+            <div className = "col">
+              <h3 style={title}>Our art, based on <em>your</em> preferences. </h3>
+            </div>
+        </div>
+        <ul>
+          <p style={subtitle}>You have selected our <strong>Basic Access</strong> package. Below is a sampling of the artwork we will send you, based on your profile preferences of:</p>
+                {props.profile.tags.map((tag)=>{
+                      return <li style={list}>{tag.name}</li>
+                  }) } 
+        </ul>
+        <div className = "row">            
+          {pieces}
+        </div>
+      </div>
+  )
 }
 
 export default Filtered_Art

--- a/src/components/pages/Art_Folder/Filtered_Art.js
+++ b/src/components/pages/Art_Folder/Filtered_Art.js
@@ -11,11 +11,6 @@ const button = {
     margin: '10px',
   }
 
-const box = {
-    textAlign: 'center',
-    // margin: '2px',
-    padding: '5px'
-  }
 
 const Filtered_Art = (props) => {
 
@@ -45,7 +40,7 @@ const Filtered_Art = (props) => {
                 artist = {a.artist}
                 imgUrl = {a.imgUrl}
                 description = {a.description}
-                price = {a.price}
+                // price = {a.price}
             />
         })
     }
@@ -67,34 +62,20 @@ const Filtered_Art = (props) => {
             <div className="row">
                 <div className = "col">
                     <h3>Our art, your preferences. </h3>
+                </div>
+                <div className = "col">
+                    <Button onClick={redirectToCheckout} variant="light" style={button} className = "btn btn-outline-success">Proceed to Checkout <text>&#8594;</text></Button>
+                </div>
+              </div>
                         {/* used to work now it doesn't consistently{
                     props.profile.tags.map((tag)=>{
                         return tag.name
                     }) } */}
                     <p>Below is a sampling of the artwork we will send you, based on your profile preferences. You can update preferences anytime in your profile.</p>
-
-                    <Row xs={1} md={2} className="g-4">
-  {Array.from({ length: 4 }).map((_, idx) => (
-    <Col style={box}>
-      <Card>
-        <Card.Img variant="top" src="https://upload.wikimedia.org/wikipedia/en/7/7c/Brushstrokes.png" />
-        <Card.Body>
-          <Card.Title>Card title</Card.Title>
-          <Card.Text>
-            Text goes here if needed.
-          </Card.Text>
-        </Card.Body>
-      </Card>
-    </Col>
-  ))}
-</Row>
-
-                </div>
-                <div className = "col">
-                    <Button onClick={redirectToCheckout} variant="light" style={button} className = "btn btn-outline-success">Proceed to Checkout <text>&#8594;</text></Button>
-                </div>
-            </div>
-            {pieces}
+        
+              <div className = "row">            
+                {pieces}
+              </div>
         </div>
     )
 }

--- a/src/components/pages/Art_Folder/Filtered_Art.js
+++ b/src/components/pages/Art_Folder/Filtered_Art.js
@@ -73,14 +73,6 @@ const Filtered_Art = (props) => {
         return navigate('/subscription/checkout')
       }
 
-    // the return section doesn't like this function for some reason
-    // const chosenTags = () => {
-    //     props.profile.tags.map((tag)=>{
-    //         return tag.name
-    //         // try .join(',')
-    //     }) 
-    // }
-
     return (
         <div>
           <div style={buttonContainer}>
@@ -97,7 +89,6 @@ const Filtered_Art = (props) => {
                         return <li style={list}>{tag.name}</li>
                     }) } 
           </ul>
-
           <div className = "row">            
             {pieces}
           </div>

--- a/src/components/pages/Art_Folder/Pieces.js
+++ b/src/components/pages/Art_Folder/Pieces.js
@@ -1,16 +1,39 @@
 
+import { Card } from 'react-bootstrap'
+
+
 const Pieces = (props) => {
 
     const imgStyle = {
-        width: '500px'
+        width: '350px',
+        height: "350px",
+        objectFit: 'cover'
+
+    }
+    const cardStyle = {
+        textAlign: 'center',
+        width: '350px'    
+    }
+
+    const title = {
+        fontSize: '20px',
+        textAlign: 'center',
+        marginTop: '25px'
+    }
+    
+    const subtitle = {
+        fontSize: '14px',
+        textAlign: 'center',
+        margin: "10px 15px"
     }
     return (
-        <div>
-            <h2>{props.title}</h2>
-            <h4>Artist: {props.artist}</h4>
-            <h5>Price: ${props.price}</h5>
+        <div className = "col">  
+            <Card style={cardStyle}>
             <img style={imgStyle} src={props.imgUrl}></img>
-            <p>Description: {props.description}</p>
+            <h2 style={title}>{props.title}</h2>
+            <h4 style={subtitle}>Artist: {props.artist}</h4>
+            <p style={subtitle}>Description: {props.description}</p>
+            </Card>
         </div>
     )
 }

--- a/src/components/pages/Art_Folder/Pieces.js
+++ b/src/components/pages/Art_Folder/Pieces.js
@@ -8,19 +8,16 @@ const Pieces = (props) => {
         width: '350px',
         height: "350px",
         objectFit: 'cover'
-
     }
     const cardStyle = {
         textAlign: 'center',
         width: '350px'    
     }
-
     const title = {
         fontSize: '20px',
         textAlign: 'center',
         marginTop: '25px'
     }
-    
     const subtitle = {
         fontSize: '14px',
         textAlign: 'center',

--- a/src/components/pages/Art_Folder/Pieces_All.js
+++ b/src/components/pages/Art_Folder/Pieces_All.js
@@ -1,26 +1,21 @@
-
 import { Card } from 'react-bootstrap'
 
-
+// this document is similar to the Pieces.js, except the desciptions of each piece are commented out.
 const Pieces = (props) => {
-
     const imgStyle = {
         width: '350px',
         height: "350px",
         objectFit: 'cover'
-
     }
     const cardStyle = {
         textAlign: 'center',
         width: '350px'    
     }
-
     const title = {
         fontSize: '20px',
         textAlign: 'center',
         marginTop: '25px'
     }
-    
     const subtitle = {
         fontSize: '14px',
         textAlign: 'center',

--- a/src/components/pages/Art_Folder/Pieces_All.js
+++ b/src/components/pages/Art_Folder/Pieces_All.js
@@ -1,0 +1,41 @@
+
+import { Card } from 'react-bootstrap'
+
+
+const Pieces = (props) => {
+
+    const imgStyle = {
+        width: '350px',
+        height: "350px",
+        objectFit: 'cover'
+
+    }
+    const cardStyle = {
+        textAlign: 'center',
+        width: '350px'    
+    }
+
+    const title = {
+        fontSize: '20px',
+        textAlign: 'center',
+        marginTop: '25px'
+    }
+    
+    const subtitle = {
+        fontSize: '14px',
+        textAlign: 'center',
+        margin: "10px 15px"
+    }
+    return (
+        <div className = "col">  
+            <Card style={cardStyle}>
+            <img style={imgStyle} src={props.imgUrl}></img>
+            <h2 style={title}>{props.title}</h2>
+            <h4 style={subtitle}>Artist: {props.artist}</h4>
+            {/* <p style={subtitle}>Description: {props.description}</p> */}
+            </Card>
+        </div>
+    )
+}
+
+export default Pieces

--- a/src/components/pages/Home_Folder/Home.js
+++ b/src/components/pages/Home_Folder/Home.js
@@ -8,13 +8,11 @@ const text = {
 	margin: '50px',
 	fontSize: '40px'
 }
-
 const title = {
 	fontSize: '40px',
 	textAlign: 'center',
 	margin: '50px'
 }
-
 const subtitle = {
 	fontSize: '20px',
 	textAlign: 'center',

--- a/src/components/pages/Profile_Folder/CreateProfile.js
+++ b/src/components/pages/Profile_Folder/CreateProfile.js
@@ -16,7 +16,23 @@ const button = {
 }
 
 const bgc = {
-  backgroundColor: 'lightgrey'
+  backgroundColor: 'lightgrey',
+  marginTop: "20px",
+  padding: '25px'
+}
+
+const title = {
+  fontSize: '40px',
+  textAlign: 'left',
+  margin: '20px'
+}
+
+const subtitle = {
+	fontSize: '20px',
+}
+
+const list = {
+  listStyle: 'none'
 }
 
 const CreateProfile = (props) => {
@@ -108,28 +124,28 @@ const CreateProfile = (props) => {
   return (
     <div>
       <div className='container' style={bgc}>
-        <h5>Create a Profile</h5>
+        <h1 style={title}>Create a Profile</h1>
         <Form onSubmit={postProfile}>
           <div className='container' style={box}>
             <Form.Group className="mb-3" controlId="formBasicEmail">
-              <Form.Label>Name</Form.Label>
+              <Form.Label style={subtitle}>Name</Form.Label>
               <Form.Control style={{ width: '18rem' }} placeholder="Enter name" onChange={handleChange} type="text" name="name" id="name" />
             </Form.Group>
           </div>
 
           <div className='container' style={box}>
             <Form.Group className="mb-3" controlId="formBasicPassword">
-              <Form.Label>Address</Form.Label>
+              <Form.Label style={subtitle}>Address</Form.Label>
               <Form.Control style={{ width: '18rem' }} placeholder="Address" onChange={handleChange} type="text" name="address" id="address" />
             </Form.Group>
           </div>
 
           <div className='container' style={box}>
             <Card style={{ width: '18rem' }}>
-              <Card.Header>Favorites</Card.Header>
+              <Card.Header style={subtitle}>Favorites</Card.Header>
               {
                 tags.map(tag => (
-                  <li>
+                  <li style={list}>
                     <label htmlFor={tag.name}>{tag.name}</label>
                     <input onChange={handleCheck} type="checkbox" name={tag.name} id={tag._id} style={button} />
                   </li>

--- a/src/components/pages/Profile_Folder/CreateProfile.js
+++ b/src/components/pages/Profile_Folder/CreateProfile.js
@@ -10,27 +10,22 @@ const box = {
   margin: '2px',
   padding: '5px'
 }
-
 const button = {
   margin: '10px',
 }
-
 const bgc = {
   backgroundColor: 'lightgrey',
   marginTop: "20px",
   padding: '25px'
 }
-
 const title = {
   fontSize: '40px',
   textAlign: 'left',
   margin: '20px'
 }
-
 const subtitle = {
 	fontSize: '20px',
 }
-
 const list = {
   listStyle: 'none'
 }
@@ -41,7 +36,6 @@ const CreateProfile = (props) => {
 
   // Setting a state to hold our users newProfile that will be sent to data Base to be stored with usersId as reference
   // Also setting a state for our tags
-
   const [newProfile, setNewProfile] = useState({
     //Other stuff will go in this object but basically we need to declare a property called tags as an array so that the spread operator will work in the first call of handleCheck
     tags: [],
@@ -51,21 +45,18 @@ const CreateProfile = (props) => {
   const [tags, setTags] = useState([])
 
   // useEffect that calls getTags everytime the component renders
-
   useEffect(() => {
     getTags()
   }, [])
 
   // Function that runs everytime that a input for either name or address changes
   // Function sets all inputs to our newProfile state
-
   const handleChange = e => {
     setNewProfile({ ...newProfile, [e.target.name]: e.target.value })
   }
 
   // This function will run everytime one of the profile checkboxes change
   // Based on checked stats of the checkbox will either add or remove the targeted tag to newProfile
-
   const handleCheck = e => {
     if (e.target.checked) {
       setNewProfile({ ...newProfile, tags: [...newProfile.tags, e.target.id] })
@@ -79,7 +70,6 @@ const CreateProfile = (props) => {
   }
 
   // this is the API call for tags at end of funciton sets found tags to our tag state
-
   const getTags = () => {
     fetch('http://localhost:8000/tags')
       .then(res => res.json())
@@ -94,7 +84,6 @@ const CreateProfile = (props) => {
   // This funciton is set to run once the submit profile button is pressed
   // This sets the newProfile state to a object that is then sent to our Data Base as a POST request
   // At the end of function getProfile and patchProfile are run to ensure that profile data in App.js is up to date
-
   const postProfile = (e) => {
     e.preventDefault()
     console.log('Pressed Submit button')
@@ -114,10 +103,10 @@ const CreateProfile = (props) => {
       },
     }
     fetch('http://localhost:8000/profiles', requestOptions)
-    .then(postedProfile=> {
-      props.getProfile()
-      navigate('/')
-    })
+      .then(postedProfile=> {
+        props.getProfile()
+        navigate('/')
+      })
       .catch(err => console.error(err))
   }
 
@@ -132,14 +121,12 @@ const CreateProfile = (props) => {
               <Form.Control style={{ width: '18rem' }} placeholder="Enter name" onChange={handleChange} type="text" name="name" id="name" />
             </Form.Group>
           </div>
-
           <div className='container' style={box}>
             <Form.Group className="mb-3" controlId="formBasicPassword">
               <Form.Label style={subtitle}>Address</Form.Label>
               <Form.Control style={{ width: '18rem' }} placeholder="Address" onChange={handleChange} type="text" name="address" id="address" />
             </Form.Group>
           </div>
-
           <div className='container' style={box}>
             <Card style={{ width: '18rem' }}>
               <Card.Header style={subtitle}>Favorites</Card.Header>
@@ -156,12 +143,10 @@ const CreateProfile = (props) => {
           <Button variant="light" type="submit" style={button}>
             Submit
           </Button>
-
         </Form>
       </div>
     </div>
   )
 }
-
 
 export default CreateProfile

--- a/src/components/pages/Profile_Folder/EditProfile.js
+++ b/src/components/pages/Profile_Folder/EditProfile.js
@@ -10,33 +10,27 @@ const box = {
   margin: '2px',
   padding: '5px'
 }
-
 const button = {
   margin: '10px',
 }
-
 const bgc = {
   backgroundColor: 'lightgrey',
   marginTop: "20px",
   padding: '25px'
 }
-
 const fav = {
   textAlign: 'left',
   margin: '2px',
   listStyle: 'none'
 }
-
 const check = {
   padding: '5px'
 }
-
 const title = {
   fontSize: '40px',
   textAlign: 'left',
   margin: '20px'
 }
-
 const subtitle = {
 	fontSize: '20px',
 }
@@ -48,20 +42,17 @@ const EditProfile = (props) => {
 
   // State are set for our currentProfile that is passed from App.js and tags which will come from props.profile as well
   // State for tagNames an array of the tag names need for testing which tags are currently attaced to the users profile
-
   const [currentProfile, setCurrentProfile] = useState(props.profile)
   const [tags, setTags] = useState([])
   const [tagNames, setTagNames] = useState(props.profile.tags.map((e) => e.name))
 
   // call to api when components renders and gets the tags from database
-
   useEffect(() => {
     getTags()
   }, [])
 
   // A function that is called every time the name or address inputs are changed
   // Function then sets these inputs as the currentProfile state  
-
   const handleChange = e => {
     setCurrentProfile({ ...currentProfile, [e.target.name]: e.target.value })
   }
@@ -69,7 +60,6 @@ const EditProfile = (props) => {
   // Function that runs any time user checks or unchecks one of the tag boxes
   // Runs logic that either removes or addes tag object to currentProfile
   // Also either removes or addes tag name to tagNames state
-
   const handleCheck = e => {
     if (e.target.checked) {
       setCurrentProfile({ ...currentProfile, tags: [...currentProfile.tags, { _id: e.target.id, name: e.target.name }] })
@@ -85,7 +75,6 @@ const EditProfile = (props) => {
   }
 
   // api call the gets the tags
-
   const getTags = () => {
     fetch('http://localhost:8000/tags')
       .then(res => res.json())
@@ -98,7 +87,6 @@ const EditProfile = (props) => {
   // Function runs when Edit Profile button is pressed
   // Sets currentProfile state to an object that is sent to our data base as a PATCH request
   // At the end getProfile is run to ensure that profile is up to date inside App.js
-
   const patchProfile = (e) => {
     e.preventDefault()
     let preJSONBody = {
@@ -127,7 +115,6 @@ const EditProfile = (props) => {
   // Function runs any time user press the cancle subscription button
   // Sends a object with only the isSubscribed attribute as a PATCH request to our data base
   // At end runs getProfile to ensure that our profile in App.js is up to date
-
   const patchSubscription = (e) => {
     e.preventDefault()
     let preJSONBody = {
@@ -150,7 +137,6 @@ const EditProfile = (props) => {
   }
 
   // Funtion that runs when cancle button is pressed that takes user back to existing profile
-
   const goBack = () => {
     return navigate('/profile')
   }
@@ -159,7 +145,6 @@ const EditProfile = (props) => {
     <div>
       <div className='container' style={bgc}>
         <h1 style={title}>Edit Profile</h1>
-
         <Form onSubmit={patchProfile}>
           <div className='container' style={box}>
             <Form.Group className="mb-3" controlId="formBasicEmail">
@@ -167,16 +152,12 @@ const EditProfile = (props) => {
               <Form.Control style={{ width: '18rem' }} placeholder="Enter name" onChange={handleChange} type="text" name="name" id="name" />
             </Form.Group>
           </div>
-
           <div className='container' style={box}>
             <Form.Group className="mb-3" controlId="formBasicPassword">
               <Form.Label style={subtitle}>Address</Form.Label>
               <Form.Control style={{ width: '18rem' }} placeholder="Address" onChange={handleChange} type="text" name="address" id="address" />
             </Form.Group>
           </div>
-          
-         
-
           <div className='container' style={box}>
             <Card style={{ width: '18rem' }}>
               <Card.Header style={subtitle}>Favorite Art Categories</Card.Header>
@@ -190,20 +171,16 @@ const EditProfile = (props) => {
               }
             </Card>
           </div>
-
           <Button variant="light" type="submit" style={button}>
             Submit
           </Button>
           <Button variant="light" type="goBack" onClick={goBack} style={button}>
             Cancel
           </Button>
-
           <Button hidden={!currentProfile.isSubscribed} variant="danger" type="goBack" onClick={patchSubscription} style={button}>
             Cancle Subscription
           </Button>
-
         </Form>
-
       </div>
     </div>
   )

--- a/src/components/pages/Profile_Folder/EditProfile.js
+++ b/src/components/pages/Profile_Folder/EditProfile.js
@@ -16,7 +16,9 @@ const button = {
 }
 
 const bgc = {
-  backgroundColor: 'lightgrey'
+  backgroundColor: 'lightgrey',
+  marginTop: "20px",
+  padding: '25px'
 }
 
 const fav = {
@@ -27,6 +29,16 @@ const fav = {
 
 const check = {
   padding: '5px'
+}
+
+const title = {
+  fontSize: '40px',
+  textAlign: 'left',
+  margin: '20px'
+}
+
+const subtitle = {
+	fontSize: '20px',
 }
 
 const EditProfile = (props) => {
@@ -146,19 +158,19 @@ const EditProfile = (props) => {
   return (
     <div>
       <div className='container' style={bgc}>
-        <h5>Edit Profile</h5>
+        <h1 style={title}>Edit Profile</h1>
 
         <Form onSubmit={patchProfile}>
           <div className='container' style={box}>
             <Form.Group className="mb-3" controlId="formBasicEmail">
-              <Form.Label>Name</Form.Label>
+              <Form.Label style={subtitle}>Name</Form.Label>
               <Form.Control style={{ width: '18rem' }} placeholder="Enter name" onChange={handleChange} type="text" name="name" id="name" />
             </Form.Group>
           </div>
 
           <div className='container' style={box}>
             <Form.Group className="mb-3" controlId="formBasicPassword">
-              <Form.Label>Address</Form.Label>
+              <Form.Label style={subtitle}>Address</Form.Label>
               <Form.Control style={{ width: '18rem' }} placeholder="Address" onChange={handleChange} type="text" name="address" id="address" />
             </Form.Group>
           </div>
@@ -167,7 +179,7 @@ const EditProfile = (props) => {
 
           <div className='container' style={box}>
             <Card style={{ width: '18rem' }}>
-              <Card.Header>Favorites</Card.Header>
+              <Card.Header style={subtitle}>Favorite Art Categories</Card.Header>
               {
                 tags.map(tag => (
                   <li style={fav}>

--- a/src/components/pages/Profile_Folder/ExistingProfile.js
+++ b/src/components/pages/Profile_Folder/ExistingProfile.js
@@ -16,7 +16,9 @@ const button = {
 }
 
 const bgc = {
-  backgroundColor: 'lightgrey'
+  backgroundColor: 'lightgrey',
+  marginTop: "20px",
+  padding: '25px'
 }
 
 const password = {
@@ -32,6 +34,15 @@ const list = {
   listStyle: 'none'
 }
 
+const title = {
+  fontSize: '40px',
+  textAlign: 'left',
+  margin: '20px'
+}
+
+const subtitle = {
+	fontSize: '20px',
+}
 
 const ExistingProfile = (props) => {
 
@@ -75,10 +86,10 @@ const ExistingProfile = (props) => {
   return (
     <div>
     <div className='container' style={bgc}>
-      <h5>Profile</h5>
+      <h1 style={title}>Profile</h1>
       <div className='container' style={box}>
         <Card style={{ width: '18rem' }}>
-          <Card.Header>Account Details</Card.Header>
+          <Card.Header style={subtitle}>Account Details</Card.Header>
           <ListGroup variant="flush">
             <ListGroup.Item style={box}>{props.profile.name}</ListGroup.Item>
             <ListGroup.Item style={box}>{props.profile.address}</ListGroup.Item>
@@ -89,7 +100,7 @@ const ExistingProfile = (props) => {
 
       <div className='container' style={box}>
         <Card style={{ width: '18rem' }}>
-          <Card.Header>Favorites</Card.Header>
+          <Card.Header style={subtitle}>Favorite Art Categories</Card.Header>
           <ListGroup variant="flush">
             <ListGroup.Item style={list}>{tagsArray}</ListGroup.Item>
           </ListGroup>

--- a/src/components/pages/Profile_Folder/ExistingProfile.js
+++ b/src/components/pages/Profile_Folder/ExistingProfile.js
@@ -10,17 +10,14 @@ const box = {
   margin: '2px',
   padding: '5px'
 }
-
 const button = {
   margin: '10px',
 }
-
 const bgc = {
   backgroundColor: 'lightgrey',
   marginTop: "20px",
   padding: '25px'
 }
-
 const password = {
   cursor: 'pointer',
   textDecoration: 'none',
@@ -29,17 +26,14 @@ const password = {
   padding: '5px',
   color: 'teal'
 }
-
 const list = {
   listStyle: 'none'
 }
-
 const title = {
   fontSize: '40px',
   textAlign: 'left',
   margin: '20px'
 }
-
 const subtitle = {
 	fontSize: '20px',
 }
@@ -49,14 +43,12 @@ const ExistingProfile = (props) => {
   // seting a stat to hold our tags, subscription, and useNavigate
   // sets tags as loading until tag data comes back from dataBase
   // sets subscription to loading untill data comes back from dataBase
-
   const [tagsArray, setTagsArray] = useState([<li>Loading...</li>])
   const [subscription, setSubscription] = useState('Loading...')
   const navigate = useNavigate()
 
   // This use effect test the profile and sets outputs to page based on data
   // The useEffect is set to run everytime profile changes
-
   useEffect(() => {
     if (props.profile.tags) {
       setTagsArray(props.profile.tags.map((tag) => {
@@ -71,48 +63,42 @@ const ExistingProfile = (props) => {
   }, [props.profile])
 
   // Function that runs when user clicks Edit Profile button
-
   const editProfile = () => {
     return navigate('/profile/edit')
   }
 
   // Function that runs when user clicks Change Passwork button
-
   const changePassword = () => {
     return navigate('/change-password')
   }
   
-
   return (
     <div>
-    <div className='container' style={bgc}>
-      <h1 style={title}>Profile</h1>
-      <div className='container' style={box}>
-        <Card style={{ width: '18rem' }}>
-          <Card.Header style={subtitle}>Account Details</Card.Header>
-          <ListGroup variant="flush">
-            <ListGroup.Item style={box}>{props.profile.name}</ListGroup.Item>
-            <ListGroup.Item style={box}>{props.profile.address}</ListGroup.Item>
-            <ListGroup.Item style={box}>{subscription}</ListGroup.Item>
-            <Card.Link style={box, password} onClick={changePassword}>Change Password</Card.Link>
-          </ListGroup>
-        </Card>
+      <div className='container' style={bgc}>
+        <h1 style={title}>Profile</h1>
+        <div className='container' style={box}>
+          <Card style={{ width: '18rem' }}>
+            <Card.Header style={subtitle}>Account Details</Card.Header>
+            <ListGroup variant="flush">
+              <ListGroup.Item style={box}>{props.profile.name}</ListGroup.Item>
+              <ListGroup.Item style={box}>{props.profile.address}</ListGroup.Item>
+              <ListGroup.Item style={box}>{subscription}</ListGroup.Item>
+              <Card.Link style={box, password} onClick={changePassword}>Change Password</Card.Link>
+            </ListGroup>
+          </Card>
+        </div>
+        <div className='container' style={box}>
+          <Card style={{ width: '18rem' }}>
+            <Card.Header style={subtitle}>Favorite Art Categories</Card.Header>
+            <ListGroup variant="flush">
+              <ListGroup.Item style={list}>{tagsArray}</ListGroup.Item>
+            </ListGroup>
+          </Card>
+        </div>
+        {/* <p>{subscription}</p> */}
+        <Button onClick={editProfile} variant="light" style={button}>Edit Profile</Button>
+        {/* <button onClick={editProfile}>Edit Profile</button> */}
       </div>
-
-      <div className='container' style={box}>
-        <Card style={{ width: '18rem' }}>
-          <Card.Header style={subtitle}>Favorite Art Categories</Card.Header>
-          <ListGroup variant="flush">
-            <ListGroup.Item style={list}>{tagsArray}</ListGroup.Item>
-          </ListGroup>
-        </Card>
-      </div>
-
-      {/* <p>{subscription}</p> */}
-      <Button onClick={editProfile} variant="light" style={button}>Edit Profile</Button>
-      {/* <button onClick={editProfile}>Edit Profile</button> */}
-
-    </div>
     </div>
   )
 }

--- a/src/components/pages/Profile_Folder/ExistingProfile.js
+++ b/src/components/pages/Profile_Folder/ExistingProfile.js
@@ -93,6 +93,7 @@ const ExistingProfile = (props) => {
           <ListGroup variant="flush">
             <ListGroup.Item style={box}>{props.profile.name}</ListGroup.Item>
             <ListGroup.Item style={box}>{props.profile.address}</ListGroup.Item>
+            <ListGroup.Item style={box}>{subscription}</ListGroup.Item>
             <Card.Link style={box, password} onClick={changePassword}>Change Password</Card.Link>
           </ListGroup>
         </Card>
@@ -107,7 +108,7 @@ const ExistingProfile = (props) => {
         </Card>
       </div>
 
-      <p>{subscription}</p>
+      {/* <p>{subscription}</p> */}
       <Button onClick={editProfile} variant="light" style={button}>Edit Profile</Button>
       {/* <button onClick={editProfile}>Edit Profile</button> */}
 

--- a/src/components/pages/Subscription_Folder/Checkout.js
+++ b/src/components/pages/Subscription_Folder/Checkout.js
@@ -7,7 +7,6 @@ import CheckoutForm from './CheckoutForm';
 // recreating the `Stripe` object on every render.
 const stripePromise = loadStripe("pk_test_51K6PZKAPJKSXew76gFW4UmquGYQXmllbtBUGoJUnMv9NUIMZLBbLqogc6cwPxKEkVw9CpxmyPoMTfO0ue0HSw5ZQ00qoIaU4tC");
 
-
 //message to appear if card payment is successful
 const successMessage = () => {
     
@@ -94,7 +93,7 @@ function Checkout(props) {
 
     // API CALL
     const patchProfile = () =>{
-        successMessage()
+        // successMessage()
         console.log('Pressed Submit button')
         let preJSONBody = {
                 isSubscribed: subscriptionCompleted,

--- a/src/components/pages/Subscription_Folder/Subscription.js
+++ b/src/components/pages/Subscription_Folder/Subscription.js
@@ -84,7 +84,7 @@ function Subscription(props) {
       <h4 style={subtitle}>Become a member to access a forever-rotating curated collection of art. No commitments. Pause or cancel anytime.</h4>
       <div>
         <Row style={box}>
-          <Card style={{ width: '18rem', margin: '20px', backgroundColor: "#E4F2F2", border: "none" }}>
+          <Card style={{ width: '18rem', margin: '20px', backgroundColor: "#D3D3D3", border: "none" }}>
             <Card.Body>
             <Card.Title>Basic Access</Card.Title>
               <Card.Text>
@@ -102,7 +102,7 @@ function Subscription(props) {
           </Card>
           <br />
 
-          <Card border="dark" style={{ width: '18rem', margin: '20px', backgroundColor: "#E4F2F2", border: "none" }}>
+          <Card border="dark" style={{ width: '18rem', margin: '20px', backgroundColor: "#D3D3D3", border: "none" }}>
             <Card.Body>
               <Card.Title>Value Access</Card.Title>
               <Card.Text>
@@ -118,7 +118,7 @@ function Subscription(props) {
           </Card>
           <br />
 
-          <Card border="dark" style={{ width: '18rem', margin: '20px', backgroundColor: "#E4F2F2", border: "none" }}>
+          <Card border="dark" style={{ width: '18rem', margin: '20px', backgroundColor: "#D3D3D3", border: "none" }}>
             <Card.Body>
               <Card.Title>Premium Access</Card.Title>
               <Card.Text>

--- a/src/components/pages/Subscription_Folder/Subscription.js
+++ b/src/components/pages/Subscription_Folder/Subscription.js
@@ -5,7 +5,7 @@ import SignIn from '../../auth/SignIn'
 import messages from '../../shared/AutoDismissAlert/messages'
 import { Card, Button, Row, Col, CardGroup } from 'react-bootstrap'
 
-
+// styling
 const button = {
   margin: '20px',
 }
@@ -46,7 +46,6 @@ function Subscription(props) {
   // tests if user is populated
   // if populated will go onto next test for profile
   // if passes all tests will enter checkout page
-
   const handleClick = (e) => {
     // Check for signed in
     if (props.user === null) {
@@ -101,7 +100,6 @@ function Subscription(props) {
             </Card.Body>
           </Card>
           <br />
-
           <Card border="dark" style={{ width: '18rem', margin: '20px', backgroundColor: "#D3D3D3", border: "none" }}>
             <Card.Body>
               <Card.Title>Value Access</Card.Title>
@@ -117,7 +115,6 @@ function Subscription(props) {
             </Card.Body>
           </Card>
           <br />
-
           <Card border="dark" style={{ width: '18rem', margin: '20px', backgroundColor: "#D3D3D3", border: "none" }}>
             <Card.Body>
               <Card.Title>Premium Access</Card.Title>
@@ -134,7 +131,6 @@ function Subscription(props) {
           </Card>
         </Row>
       </div>
-
       <div style={iconBoxesContainer}>
         <Row xs={1} md={2} className="g-4" style={iconBoxesContainer}>
           <Card style={{width: "400px", margin: "25px" }} >
@@ -160,6 +156,17 @@ function Subscription(props) {
             </Card.Body>
           </Card>
           <Card style={{width: "400px", margin: "25px" }} >
+            <svg style={icon} xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-person" viewBox="0 0 16 16">
+              <path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm2-3a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm4 8c0 1-1 1-1 1H3s-1 0-1-1 1-4 6-4 6 3 6 4zm-1-.004c-.001-.246-.154-.986-.832-1.664C11.516 10.68 10.289 10 8 10c-2.29 0-3.516.68-4.168 1.332-.678.678-.83 1.418-.832 1.664h10z" />
+            </svg>
+            <Card.Body>
+              <Card.Title>Members-Only Sales</Card.Title>
+              <Card.Text>
+                Get exclusive discounts on purchases.
+              </Card.Text>
+            </Card.Body>
+          </Card>
+          <Card style={{width: "400px", margin: "25px" }} >
             <svg style={icon} xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-receipt" viewBox="0 0 16 16">
               <path d="M1.92.506a.5.5 0 0 1 .434.14L3 1.293l.646-.647a.5.5 0 0 1 .708 0L5 1.293l.646-.647a.5.5 0 0 1 .708 0L7 1.293l.646-.647a.5.5 0 0 1 .708 0L9 1.293l.646-.647a.5.5 0 0 1 .708 0l.646.647.646-.647a.5.5 0 0 1 .708 0l.646.647.646-.647a.5.5 0 0 1 .801.13l.5 1A.5.5 0 0 1 15 2v12a.5.5 0 0 1-.053.224l-.5 1a.5.5 0 0 1-.8.13L13 14.707l-.646.647a.5.5 0 0 1-.708 0L11 14.707l-.646.647a.5.5 0 0 1-.708 0L9 14.707l-.646.647a.5.5 0 0 1-.708 0L7 14.707l-.646.647a.5.5 0 0 1-.708 0L5 14.707l-.646.647a.5.5 0 0 1-.708 0L3 14.707l-.646.647a.5.5 0 0 1-.801-.13l-.5-1A.5.5 0 0 1 1 14V2a.5.5 0 0 1 .053-.224l.5-1a.5.5 0 0 1 .367-.27zm.217 1.338L2 2.118v11.764l.137.274.51-.51a.5.5 0 0 1 .707 0l.646.647.646-.646a.5.5 0 0 1 .708 0l.646.646.646-.646a.5.5 0 0 1 .708 0l.646.646.646-.646a.5.5 0 0 1 .708 0l.646.646.646-.646a.5.5 0 0 1 .708 0l.646.646.646-.646a.5.5 0 0 1 .708 0l.509.509.137-.274V2.118l-.137-.274-.51.51a.5.5 0 0 1-.707 0L12 1.707l-.646.647a.5.5 0 0 1-.708 0L10 1.707l-.646.647a.5.5 0 0 1-.708 0L8 1.707l-.646.647a.5.5 0 0 1-.708 0L6 1.707l-.646.647a.5.5 0 0 1-.708 0L4 1.707l-.646.647a.5.5 0 0 1-.708 0l-.509-.51z" />
               <path d="M3 4.5a.5.5 0 0 1 .5-.5h6a.5.5 0 1 1 0 1h-6a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h6a.5.5 0 1 1 0 1h-6a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h6a.5.5 0 1 1 0 1h-6a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 0 1h-6a.5.5 0 0 1-.5-.5zm8-6a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 0 1h-1a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 0 1h-1a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 0 1h-1a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 0 1h-1a.5.5 0 0 1-.5-.5z" />
@@ -171,21 +178,9 @@ function Subscription(props) {
               </Card.Text>
             </Card.Body>
           </Card>
-          <Card style={{width: "400px", margin: "25px" }} >
-            <svg style={icon} xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-person" viewBox="0 0 16 16">
-              <path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm2-3a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm4 8c0 1-1 1-1 1H3s-1 0-1-1 1-4 6-4 6 3 6 4zm-1-.004c-.001-.246-.154-.986-.832-1.664C11.516 10.68 10.289 10 8 10c-2.29 0-3.516.68-4.168 1.332-.678.678-.83 1.418-.832 1.664h10z" />
-            </svg>
-            <Card.Body>
-              <Card.Title>Members-Only Sales</Card.Title>
-              <Card.Text>
-                Get exclusive discounts on purchases.
-              </Card.Text>
-            </Card.Body>
-          </Card>
 
         </Row>
       </div>
-
       <div className='container'>
         <h2 style={box}>How it Works</h2>
         <CardGroup className=''>
@@ -205,8 +200,6 @@ function Subscription(props) {
           </Card>
         </CardGroup>
       </div>
-
-
     </div>
   )
 }

--- a/src/components/pages/Subscription_Folder/Subscription.js
+++ b/src/components/pages/Subscription_Folder/Subscription.js
@@ -11,13 +11,29 @@ const button = {
 }
 const box = {
   justifyContent: 'center',
-  margin: '25px'
+  textAlign: 'center',
+  padding: '25px'
 }
 const icon = {
-  margin: '15px'
+  margin: '15 auto',
+  height: "75px",
+  width: "75px",
 }
 const title = {
-  margin: '25px'
+	fontSize: '40px',
+	textAlign: 'center',
+	margin: '50px'
+}
+const subtitle = {
+	fontSize: '20px',
+	textAlign: 'center',
+	width: "720px",
+	margin: "0 auto",
+	paddingBottom: "20px"
+}
+const iconBoxesContainer = {
+	textAlign: 'center',
+  justifyContent: 'center'
 }
 
 // function that renders Subscription Page
@@ -65,10 +81,10 @@ function Subscription(props) {
   return (
     <div className="container">
       <h2 style={title}>Pick a Plan</h2>
-      <h4>Become a member to access a forever-rotating curated collection of art. No commitments. Pause or cancel anytime.</h4>
+      <h4 style={subtitle}>Become a member to access a forever-rotating curated collection of art. No commitments. Pause or cancel anytime.</h4>
       <div>
         <Row style={box}>
-          <Card style={box} border="dark" style={{ width: '18rem' }}>
+          <Card style={{ width: '18rem', margin: '20px', backgroundColor: "#E4F2F2", border: "none" }}>
             <Card.Body>
             <Card.Title>Basic Access</Card.Title>
               <Card.Text>
@@ -82,12 +98,11 @@ function Subscription(props) {
                 1 shipment per season <br></br>
                 <b>$89</b> trial season <br></br>$109/season after
               </Card.Text>
-
             </Card.Body>
           </Card>
           <br />
 
-          <Card style={box} border="dark" style={{ width: '18rem' }}>
+          <Card border="dark" style={{ width: '18rem', margin: '20px', backgroundColor: "#E4F2F2", border: "none" }}>
             <Card.Body>
               <Card.Title>Value Access</Card.Title>
               <Card.Text>
@@ -103,7 +118,7 @@ function Subscription(props) {
           </Card>
           <br />
 
-          <Card style={box} border="dark" style={{ width: '18rem' }}>
+          <Card border="dark" style={{ width: '18rem', margin: '20px', backgroundColor: "#E4F2F2", border: "none" }}>
             <Card.Body>
               <Card.Title>Premium Access</Card.Title>
               <Card.Text>
@@ -120,10 +135,9 @@ function Subscription(props) {
         </Row>
       </div>
 
-      <div>
-        <Row xs={1} md={2} className="g-4">
-
-          <Card border="success">
+      <div style={iconBoxesContainer}>
+        <Row xs={1} md={2} className="g-4" style={iconBoxesContainer}>
+          <Card style={{width: "400px", margin: "25px" }} >
             <svg style={icon} xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-truck" viewBox="0 0 16 16">
               <path d="M0 3.5A1.5 1.5 0 0 1 1.5 2h9A1.5 1.5 0 0 1 12 3.5V5h1.02a1.5 1.5 0 0 1 1.17.563l1.481 1.85a1.5 1.5 0 0 1 .329.938V10.5a1.5 1.5 0 0 1-1.5 1.5H14a2 2 0 1 1-4 0H5a2 2 0 1 1-3.998-.085A1.5 1.5 0 0 1 0 10.5v-7zm1.294 7.456A1.999 1.999 0 0 1 4.732 11h5.536a2.01 2.01 0 0 1 .732-.732V3.5a.5.5 0 0 0-.5-.5h-9a.5.5 0 0 0-.5.5v7a.5.5 0 0 0 .294.456zM12 10a2 2 0 0 1 1.732 1h.768a.5.5 0 0 0 .5-.5V8.35a.5.5 0 0 0-.11-.312l-1.48-1.85A.5.5 0 0 0 13.02 6H12v4zm-9 1a1 1 0 1 0 0 2 1 1 0 0 0 0-2zm9 0a1 1 0 1 0 0 2 1 1 0 0 0 0-2z" />
             </svg>
@@ -134,7 +148,7 @@ function Subscription(props) {
               </Card.Text>
             </Card.Body>
           </Card>
-          <Card border="success">
+          <Card style={{width: "400px", margin: "25px" }} >
             <svg style={icon} xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-recycle" viewBox="0 0 16 16">
               <path d="M9.302 1.256a1.5 1.5 0 0 0-2.604 0l-1.704 2.98a.5.5 0 0 0 .869.497l1.703-2.981a.5.5 0 0 1 .868 0l2.54 4.444-1.256-.337a.5.5 0 1 0-.26.966l2.415.647a.5.5 0 0 0 .613-.353l.647-2.415a.5.5 0 1 0-.966-.259l-.333 1.242-2.532-4.431zM2.973 7.773l-1.255.337a.5.5 0 1 1-.26-.966l2.416-.647a.5.5 0 0 1 .612.353l.647 2.415a.5.5 0 0 1-.966.259l-.333-1.242-2.545 4.454a.5.5 0 0 0 .434.748H5a.5.5 0 0 1 0 1H1.723A1.5 1.5 0 0 1 .421 12.24l2.552-4.467zm10.89 1.463a.5.5 0 1 0-.868.496l1.716 3.004a.5.5 0 0 1-.434.748h-5.57l.647-.646a.5.5 0 1 0-.708-.707l-1.5 1.5a.498.498 0 0 0 0 .707l1.5 1.5a.5.5 0 1 0 .708-.707l-.647-.647h5.57a1.5 1.5 0 0 0 1.302-2.244l-1.716-3.004z" />
             </svg>
@@ -145,7 +159,7 @@ function Subscription(props) {
               </Card.Text>
             </Card.Body>
           </Card>
-          <Card border="success">
+          <Card style={{width: "400px", margin: "25px" }} >
             <svg style={icon} xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-receipt" viewBox="0 0 16 16">
               <path d="M1.92.506a.5.5 0 0 1 .434.14L3 1.293l.646-.647a.5.5 0 0 1 .708 0L5 1.293l.646-.647a.5.5 0 0 1 .708 0L7 1.293l.646-.647a.5.5 0 0 1 .708 0L9 1.293l.646-.647a.5.5 0 0 1 .708 0l.646.647.646-.647a.5.5 0 0 1 .708 0l.646.647.646-.647a.5.5 0 0 1 .801.13l.5 1A.5.5 0 0 1 15 2v12a.5.5 0 0 1-.053.224l-.5 1a.5.5 0 0 1-.8.13L13 14.707l-.646.647a.5.5 0 0 1-.708 0L11 14.707l-.646.647a.5.5 0 0 1-.708 0L9 14.707l-.646.647a.5.5 0 0 1-.708 0L7 14.707l-.646.647a.5.5 0 0 1-.708 0L5 14.707l-.646.647a.5.5 0 0 1-.708 0L3 14.707l-.646.647a.5.5 0 0 1-.801-.13l-.5-1A.5.5 0 0 1 1 14V2a.5.5 0 0 1 .053-.224l.5-1a.5.5 0 0 1 .367-.27zm.217 1.338L2 2.118v11.764l.137.274.51-.51a.5.5 0 0 1 .707 0l.646.647.646-.646a.5.5 0 0 1 .708 0l.646.646.646-.646a.5.5 0 0 1 .708 0l.646.646.646-.646a.5.5 0 0 1 .708 0l.646.646.646-.646a.5.5 0 0 1 .708 0l.646.646.646-.646a.5.5 0 0 1 .708 0l.509.509.137-.274V2.118l-.137-.274-.51.51a.5.5 0 0 1-.707 0L12 1.707l-.646.647a.5.5 0 0 1-.708 0L10 1.707l-.646.647a.5.5 0 0 1-.708 0L8 1.707l-.646.647a.5.5 0 0 1-.708 0L6 1.707l-.646.647a.5.5 0 0 1-.708 0L4 1.707l-.646.647a.5.5 0 0 1-.708 0l-.509-.51z" />
               <path d="M3 4.5a.5.5 0 0 1 .5-.5h6a.5.5 0 1 1 0 1h-6a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h6a.5.5 0 1 1 0 1h-6a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h6a.5.5 0 1 1 0 1h-6a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 0 1h-6a.5.5 0 0 1-.5-.5zm8-6a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 0 1h-1a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 0 1h-1a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 0 1h-1a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 0 1h-1a.5.5 0 0 1-.5-.5z" />
@@ -157,7 +171,7 @@ function Subscription(props) {
               </Card.Text>
             </Card.Body>
           </Card>
-          <Card border="success">
+          <Card style={{width: "400px", margin: "25px" }} >
             <svg style={icon} xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-person" viewBox="0 0 16 16">
               <path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm2-3a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm4 8c0 1-1 1-1 1H3s-1 0-1-1 1-4 6-4 6 3 6 4zm-1-.004c-.001-.246-.154-.986-.832-1.664C11.516 10.68 10.289 10 8 10c-2.29 0-3.516.68-4.168 1.332-.678.678-.83 1.418-.832 1.664h10z" />
             </svg>
@@ -175,7 +189,7 @@ function Subscription(props) {
       <div className='container'>
         <h2 style={box}>How it Works</h2>
         <CardGroup className=''>
-          <Card>
+          <Card style={box}>
             <Card.Body>
 
               <Card.Text>


### PR DESCRIPTION
Styled the cards on the art collection page and filtered art page. Created a duplicate pieces.js (called pieces_all.js) that purposely does not bring in the art description. Styled sign in/login/profile pages to be consistent with each other. Data seems to seed correctly, with pulling in the different artwork for the different tags: for the collection page, the art displays in rows organized by tag. For the filtered page, artwork correctly displays when one or more tags are selected from profile.

All seems good. 